### PR TITLE
Allow options to be set via HTML data attributes.

### DIFF
--- a/jquery-check-all.js
+++ b/jquery-check-all.js
@@ -21,7 +21,7 @@
 
   function checkAll(element, options) {
     this.$el = $(element);
-    this.options = $.extend({}, defaults, options) ;
+    this.options = $.extend({}, defaults, this.$el.data(), options) ;
     this.init();
   }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,3 +1,18 @@
+test('with no options set', function() {
+    $('#all').checkAll();
+
+    // check
+    $('#all').trigger('click');
+    equal($('input[type=checkbox]:checked').length, $('input[type=checkbox]').length);
+
+    //explicitly test all checkboxes are checked including the lonely one
+    equal(true, $('#lonely-checkbox').is(':checked'));
+
+    // uncheck
+    $('#all').trigger('click');
+    equal(0, $('input[type=checkbox]:checked').length);
+});
+
 test('with container set', function() {
   var containerSelector = '#group1';
 
@@ -14,6 +29,23 @@ test('with container set', function() {
   equal(0, $('input[type=checkbox]:checked', containerSelector).length);
 });
 
+test('with container set via data attribute', function() {
+    var containerSelector = '#group1';
+
+    $('#all').data('container', containerSelector);
+    $('#all').checkAll();
+
+    // check
+    $('#all').trigger('click');
+    equal($('input[type=checkbox]:checked', containerSelector).length, $('input[type=checkbox]', containerSelector).length);
+
+    equal(false, $('#lonely-checkbox').is(':checked'));
+
+    // uncheck
+    $('#all').trigger('click');
+    equal(0, $('input[type=checkbox]:checked', containerSelector).length);
+});
+
 test('with childCheckboxes set', function() {
   var childSelector = '.group1'
 
@@ -28,6 +60,23 @@ test('with childCheckboxes set', function() {
   // uncheck
   $('#all').trigger('click');
   equal(0, $('input[type=checkbox]:checked', '#group1').length);
+});
+
+test('with childCheckboxes set via data attribute', function() {
+    var childSelector = '.group1'
+
+    $('#all').data('childCheckboxes', childSelector);
+    $('#all').checkAll();
+
+    // check
+    $('#all').trigger('click');
+    equal($(childSelector).length, $(childSelector + ':checked').length);
+
+    equal(false, $('#lonely-checkbox').is(':checked'));
+
+    // uncheck
+    $('#all').trigger('click');
+    equal(0, $('input[type=checkbox]:checked', '#group1').length);
 });
 
 test('check all box checks/unchecks when children are selected/deselected', function() {
@@ -53,4 +102,21 @@ test('indeterminate state is correctly set/unset', function() {
   equal(true, $('#all').prop('indeterminate'));
   $('#child1').trigger('click');
   equal(false, $('#all').prop('indeterminate'));
+});
+
+test('indeterminate state is correctly set/unset via data attributes', function() {
+
+    $('#all').data('container', "#group1");
+    $('#all').data('showIndeterminate', true);
+    $('#all').checkAll();
+
+    equal(false, $('#all').prop('indeterminate'));
+    $('#child1').trigger('click');
+    equal(true, $('#all').prop('indeterminate'));
+    $('#child2').trigger('click');
+    equal(false, $('#all').prop('indeterminate'));
+    $('#child2').trigger('click');
+    equal(true, $('#all').prop('indeterminate'));
+    $('#child1').trigger('click');
+    equal(false, $('#all').prop('indeterminate'));
 });


### PR DESCRIPTION
This makes it easier to set and control options when you have several groups of checkboxes on a single document.
Note the options will still be overridden by any specified when calling .checkAll( {option: value} );

For example, 2 groups of checkboxes with container option defined via data attribute and a single initialiser call setting showIndeterminate TRUE:
```html
<div id="group1">
    <input id="all" type="checkbox" data-checkall data-container="#group1">
    <input id="child1" class="group1" type="checkbox">
    <input id="child2" class="group1" type="checkbox">
</div>
<div id="group2">
    <input id="all" type="checkbox" data-checkall data-container="#group2">
    <input id="child3" class="group2" type="checkbox">
    <input id="child4" class="group2" type="checkbox">
</div>
<input id="lonely-checkbox" type="checkbox">

$('[data-checkall]').checkAll({showIndeterminate:true});
```